### PR TITLE
Error fix for android13

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Add the following permissions to your `AndroidManifest.xml`, located in `<projec
 <uses-permission android:name="android.permission.CAMERA" />
 ```
 
+If your app targets Android 13 with targetSdk >= 33 then you will need to replace READ_EXTERNAL_STORAGE permission to this in your `AndroidManifest.xml`.
+[Android documentation here](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions)
+
+```
+<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+<uses-permission
+    android:name="android.permission.READ_EXTERNAL_STORAGE"
+    android:maxSdkVersion="32" />
+```
+
 ## Usage
 
 ```dart

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
-    implementation 'com.github.sangcomz:FishBun:0.11.2'
+    implementation 'io.github.sangcomz:fishbun:1.1.1'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
 }

--- a/android/src/main/kotlin/com/tianxin/multi_image_picker_plus/MultiImagePickerPlusPlugin.kt
+++ b/android/src/main/kotlin/com/tianxin/multi_image_picker_plus/MultiImagePickerPlusPlugin.kt
@@ -19,7 +19,6 @@ import androidx.exifinterface.media.ExifInterface
 import com.sangcomz.fishbun.FishBun
 import com.sangcomz.fishbun.FishBunCreator
 import com.sangcomz.fishbun.adapter.image.impl.GlideAdapter
-import com.sangcomz.fishbun.define.Define
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -152,7 +151,7 @@ class MultiImagePickerPlusPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
     if (requestCode == requestCodeChoose && resultCode == Activity.RESULT_CANCELED) {
       finishWithError("CANCELLED", "The user has cancelled the selection")
     } else if (requestCode == requestCodeChoose && resultCode == Activity.RESULT_OK) {
-      val photos: List<Uri>? = data!!.getParcelableArrayListExtra(Define.INTENT_PATH)
+      val photos: List<Uri>? = data!!.getParcelableArrayListExtra(FishBun.INTENT_PATH)
       if (photos == null) {
         clearMethodCallAndResult()
         return false

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tianxin.multi_image_picker_plus_example">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.CAMERA" />
    <application
         android:label="multi_image_picker_plus_example"


### PR DESCRIPTION
A Flutter app with multi_image_picker_plus package on Android 13 (Pixel 6a) causes error and don't display permission dialog.

So I try to fix this by updated FishBun library. And also I updated README about Android permission settings.

Please check my PR.