### PR TITLE
Fix: Typing bug

### DIFF
--- a/lib/src/cupertino_options.dart
+++ b/lib/src/cupertino_options.dart
@@ -533,43 +533,90 @@ enum PHAssetCollectionType {
 }
 
 enum PHAssetCollectionSubtype {
-  /// PHAssetCollectionTypeAlbum regular subtypes
-  albumRegular(2),
-  albumSyncedEvent(3),
-  albumSyncedFaces(4),
-  albumSyncedAlbum(5),
-  albumImported(6),
+  albumRegular,
+  albumSyncedEvent,
+  albumSyncedFaces,
+  albumSyncedAlbum,
+  albumImported,
+  albumMyPhotoStream,
+  albumCloudShared,
+  smartAlbumGeneric,
+  smartAlbumPanoramas,
+  smartAlbumVideos,
+  smartAlbumFavorites,
+  smartAlbumTimelapses,
+  smartAlbumAllHidden,
+  smartAlbumRecentlyAdded,
+  smartAlbumBursts,
+  smartAlbumSlomoVideos,
+  smartAlbumUserLibrary,
+  smartAlbumSelfPortraits,
+  smartAlbumScreenshots,
+  smartAlbumDepthEffect,
+  smartAlbumLivePhotos,
+  smartAlbumAnimated,
+  smartAlbumLongExposures,
+  smartAlbumUnableToUpload,
+  smartAlbumRAW,
+}
 
-  /// PHAssetCollectionTypeAlbum shared subtypes
-  albumMyPhotoStream(100),
-  albumCloudShared(101),
-
-  /// PHAssetCollectionTypeSmartAlbum subtypes
-  smartAlbumGeneric(200),
-  smartAlbumPanoramas(201),
-  smartAlbumVideos(202),
-  smartAlbumFavorites(203),
-  smartAlbumTimelapses(204),
-  smartAlbumAllHidden(205),
-  smartAlbumRecentlyAdded(206),
-  smartAlbumBursts(207),
-  smartAlbumSlomoVideos(208),
-  smartAlbumUserLibrary(209),
-  smartAlbumSelfPortraits(210),
-  smartAlbumScreenshots(211),
-  smartAlbumDepthEffect(212),
-  smartAlbumLivePhotos(213),
-  smartAlbumAnimated(214),
-  smartAlbumLongExposures(215),
-  smartAlbumUnableToUpload(216),
-  smartAlbumRAW(217),
-
-  /// Used for fetching, if you don't care about the exact subtype
-  any(9223372036854775807);
-
-  const PHAssetCollectionSubtype(this.code);
-
-  final int code;
+extension PHAssetCollectionSubtypeExtension on PHAssetCollectionSubtype {
+  int get code {
+    switch (this) {
+      case PHAssetCollectionSubtype.albumRegular:
+        return 2;
+      case PHAssetCollectionSubtype.albumSyncedEvent:
+        return 3;
+      case PHAssetCollectionSubtype.albumSyncedFaces:
+        return 4;
+      case PHAssetCollectionSubtype.albumSyncedAlbum:
+        return 5;
+      case PHAssetCollectionSubtype.albumImported:
+        return 6;
+      case PHAssetCollectionSubtype.albumMyPhotoStream:
+        return 100;
+      case PHAssetCollectionSubtype.albumCloudShared:
+        return 101;
+      case PHAssetCollectionSubtype.smartAlbumGeneric:
+        return 200;
+      case PHAssetCollectionSubtype.smartAlbumPanoramas:
+        return 201;
+      case PHAssetCollectionSubtype.smartAlbumVideos:
+        return 202;
+      case PHAssetCollectionSubtype.smartAlbumFavorites:
+        return 203;
+      case PHAssetCollectionSubtype.smartAlbumTimelapses:
+        return 204;
+      case PHAssetCollectionSubtype.smartAlbumAllHidden:
+        return 205;
+      case PHAssetCollectionSubtype.smartAlbumRecentlyAdded:
+        return 206;
+      case PHAssetCollectionSubtype.smartAlbumBursts:
+        return 207;
+      case PHAssetCollectionSubtype.smartAlbumSlomoVideos:
+        return 208;
+      case PHAssetCollectionSubtype.smartAlbumUserLibrary:
+        return 209;
+      case PHAssetCollectionSubtype.smartAlbumSelfPortraits:
+        return 210;
+      case PHAssetCollectionSubtype.smartAlbumScreenshots:
+        return 211;
+      case PHAssetCollectionSubtype.smartAlbumDepthEffect:
+        return 212;
+      case PHAssetCollectionSubtype.smartAlbumLivePhotos:
+        return 213;
+      case PHAssetCollectionSubtype.smartAlbumAnimated:
+        return 214;
+      case PHAssetCollectionSubtype.smartAlbumLongExposures:
+        return 215;
+      case PHAssetCollectionSubtype.smartAlbumUnableToUpload:
+        return 216;
+      case PHAssetCollectionSubtype.smartAlbumRAW:
+        return 217;
+      default:
+        return -1; // Or handle this however you'd like
+    }
+  }
 }
 
 enum PHAssetSourceType {


### PR DESCRIPTION
Bug details:

```../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:570:3: Error: Expected an identifier, but got 'const'.
Try inserting an identifier before 'const'.
  const PHAssetCollectionSubtype(this.code);
  ^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:570:3: Error: Expected '}' before this.
  const PHAssetCollectionSubtype(this.code);
  ^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:537:15: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumRegular(2),
              ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:538:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumSyncedEvent(3),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:539:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumSyncedFaces(4),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:540:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumSyncedAlbum(5),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:541:16: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumImported(6),
               ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:544:21: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumMyPhotoStream(100),
                    ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:545:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  albumCloudShared(101),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:548:20: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumGeneric(200),
                   ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:549:22: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumPanoramas(201),
                     ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:550:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumVideos(202),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:551:22: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumFavorites(203),
                     ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:552:23: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumTimelapses(204),
                      ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:553:22: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumAllHidden(205),
                     ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:554:26: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumRecentlyAdded(206),
                         ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:555:19: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumBursts(207),
                  ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:556:24: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumSlomoVideos(208),
                       ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:557:24: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumUserLibrary(209),
                       ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:558:26: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumSelfPortraits(210),
                         ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:559:24: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumScreenshots(211),
                       ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:560:24: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumDepthEffect(212),
                       ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:561:23: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumLivePhotos(213),
                      ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:562:21: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumAnimated(214),
                    ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:563:26: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumLongExposures(215),
                         ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:564:27: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumUnableToUpload(216),
                          ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:565:16: Error: Too many positional arguments: 2 allowed, but 3 found.
Try removing the extra positional arguments.
  smartAlbumRAW(217),
               ^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:535:6: Context: Found this candidate, but the arguments don't match.
enum PHAssetCollectionSubtype {
     ^^^^^^^^^^^^^^^^^^^^^^^^
../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart:422:26: Error: The getter 'code' isn't defined for the class 'PHAssetCollectionSubtype'.
 - 'PHAssetCollectionSubtype' is from 'package:multi_image_picker_plus/src/cupertino_options.dart' ('../../AppData/Local/Pub/Cache/hosted/pub.dev/multi_image_picker_plus-0.0.3/lib/src/cupertino_options.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'code'.
      'subtype': subtype.code,```